### PR TITLE
feat(pricing): surface fuzzy search across pricing + marketing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-05-28
+
+### Added
+
+- **Fuzzy / typo-tolerant search** surfaced across the marketing site:
+  - `src/data/pricing-tiers.js` — new "Fuzzy / Typo-Tolerant Search" row in the Endpoints & Features comparison (Professional+)
+  - `src/components/api-pricing.jsx` — added the capability as a Professional plan card bullet
+  - `src/components/product/api/why-choose-our-api.jsx` — new "Typo-Tolerant Search" feature card
+
 ## [1.2.0] - 2026-05-25
 
 ### Added

--- a/src/components/api-pricing.jsx
+++ b/src/components/api-pricing.jsx
@@ -75,6 +75,7 @@ const plans = [
       "All endpoints including cities by country",
       "Regions, subregions, ISO, phone dial code, and timezone APIs",
       "Field filtering (?fields=) and custom sort (?sort=) on every geographic endpoint",
+      "Fuzzy / typo-tolerant search across cities, states & countries",
       "Domain + IP whitelisting (up to 10)",
       "Founder-led priority support (~1 business day)",
       "Coming soon: GraphQL, geospatial search",

--- a/src/components/product/api/why-choose-our-api.jsx
+++ b/src/components/product/api/why-choose-our-api.jsx
@@ -8,6 +8,7 @@ import {
   Filter,
   Clock,
   Phone,
+  Search,
 } from "lucide-react";
 
 const features = [
@@ -38,6 +39,13 @@ const features = [
     description:
       "Parse E.164 numbers into country + national parts, look up dial codes, and convert ISO 3166 codes between alpha-2, alpha-3, and numeric formats.",
     color: "from-orange to-orange/90",
+  },
+  {
+    icon: Search,
+    title: "Typo-Tolerant Search",
+    description:
+      "Fuzzy search resolves misspellings, transliterations, and native-script queries — 'Banglore' finds Bangalore — with a confidence score on every match.",
+    color: "from-green to-green/90",
   },
   {
     icon: RefreshCw,

--- a/src/data/pricing-tiers.js
+++ b/src/data/pricing-tiers.js
@@ -109,6 +109,7 @@ export const COMPARISON_SECTIONS = [
       { label: "Timezone Lookup (country/state/city)", values: { community: true, starter: true, supporter: true, professional: true, business: true } },
       { label: "Fields Filtering (?fields=)", values: { community: false, starter: false, supporter: true, professional: true, business: true } },
       { label: "Sorting (?sort=)", values: { community: false, starter: false, supporter: true, professional: true, business: true } },
+      { label: "Fuzzy / Typo-Tolerant Search", values: { community: false, starter: false, supporter: false, professional: true, business: true } },
       { label: "GraphQL API", values: { community: false, starter: false, supporter: false, professional: "coming_soon", business: "coming_soon" } },
       { label: "Nearby / Geospatial Search", values: { community: false, starter: false, supporter: false, professional: "coming_soon", business: "coming_soon" } },
     ],


### PR DESCRIPTION
## Summary
Surfaces the fuzzy / typo-tolerant search endpoint (Professional+, csc-app #32) across the marketing site.

- `src/data/pricing-tiers.js` — new "Fuzzy / Typo-Tolerant Search" comparison row (Professional+); label matches csc-app `FEATURE_FLAG_LABELS`
- `src/components/api-pricing.jsx` — Professional plan-card bullet
- `src/components/product/api/why-choose-our-api.jsx` — new "Typo-Tolerant Search" feature card
- `CHANGELOG.md` — `[1.3.0]` entry

## Verification
- `npx next build` ✅ compiled successfully (`/pricing` and `/product/api` render the edited components)

Part of a cross-repo docs sync (csc-docs endpoint page + csc-app changelog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)